### PR TITLE
Install brew bundler gems before installing our formula

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,22 @@ jobs:
 
       # This action automatically installs the locally checked out tap.
       - name: Set up Homebrew
+        id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Homebrew Bundler RubyGems
+        id: gems-cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ runner.os }}-rubygems-
+
+      - name: Install Homebrew Bundler RubyGems
+        if: steps.gems-cache.outputs.cache-hit != 'true'
+        run: brew install-bundler-gems
 
       - name: Install CLI
         run: |


### PR DESCRIPTION
Based on the docs here: https://github.com/Homebrew/actions/tree/master/setup-homebrew

Should help with ruby 3 transition that's going on on right now in brew - https://github.com/Homebrew/brew/issues/16154

They haven't got around to updating the gems on their side yet, even though ruby 3 is already enabled on master branch

Without the updated gems we are getting "RuntimeError: Empty archive" from brew during installation of our formula