### PR TITLE
Installing bundler gems shouldn't be required anymore

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,9 +32,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Homebrew Bundler RubyGems
-        run: brew install-bundler-gems
-
       - name: Check the CLI formula
         run: |
           brew style databricks


### PR DESCRIPTION
Brew maintainers fixed zip extraction on macos.
I'm actually not sure if `style` command required bundler gems or not, this PR should check it