### PR TITLE
Don't pass token to setup-homebrew action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,6 @@ jobs:
       # This action automatically installs the locally checked out tap.
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check the CLI formula
         run: |


### PR DESCRIPTION
It is unclear why this was done in the first place. It is not needed.