### PR TITLE
Use stable version of Homebrew in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,23 +32,11 @@ jobs:
       - name: Configure Git
         uses: Homebrew/actions/git-user-config@master
 
-      - name: brew version
-        run: |
-          brew --version
-
       # This action automatically installs the locally checked out tap.
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
         with:
           stable: true
-
-      - name: brew version
-        run: |
-          brew --version
-
-      - name: brew repo
-        run: |
-          brew --repo
 
       - name: Check the CLI formula
         run: |


### PR DESCRIPTION
By default, the `setup-homebrew` Github action uses a development version of `brew` and installs it in CI.

Setting stable makes the github action install a released version of brew: https://github.com/Homebrew/actions/blob/84cd7c55fd330612338084d544c788d9d4a49cf7/setup-homebrew/main.sh#L162

Recently a regression was shipped to the development copy that was causing the following error. Example run: https://github.com/databricks/homebrew-tap/actions/runs/16940470803/job/48007911830
```
Error: An exception occurred within a child process:
  FormulaUnavailableError: No available formula with the name "databricks".
```

Switching to a stable version of brew fixes that issue. 