### PR TITLE
Bump GitHub Actions to Node 24 versions

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -26,7 +26,7 @@ jobs:
       labels: linux-ubuntu-latest
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Change to a new release
         run: |
@@ -38,9 +38,7 @@ jobs:
 
       - name: Create a release pull request
         id: cpr
-
-        # Version v6.0.5
-        uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           author: "eng-dev-ecosystem-bot <eng-dev-ecosystem-bot@users.noreply.github.com>"
           committer: "eng-dev-ecosystem-bot <eng-dev-ecosystem-bot@users.noreply.github.com>"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           - ubuntu-latest
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Configure Git
         uses: Homebrew/actions/git-user-config@42435f26fd0824180d7a31f0dd75afd37eb2e18f # master


### PR DESCRIPTION
Silences the Node 20 deprecation warning across all workflows.

- `actions/checkout` v4.3.1 → v6.0.2 (release-pr.yml, test.yml)
- `peter-evans/create-pull-request` v6.0.5 → v8.1.1 (release-pr.yml)

No input-level breaking changes affect these workflows.

This pull request and its description were written by Isaac.