### PR TITLE
Bump Homebrew actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,11 +30,11 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Configure Git
-        uses: Homebrew/actions/git-user-config@42435f26fd0824180d7a31f0dd75afd37eb2e18f # master
+        uses: Homebrew/actions/git-user-config@98cfa07b984a61682e6cd3a0833fad2006cc84ba # main
 
       # This action automatically installs the locally checked out tap.
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@42435f26fd0824180d7a31f0dd75afd37eb2e18f # master
+        uses: Homebrew/actions/setup-homebrew@98cfa07b984a61682e6cd3a0833fad2006cc84ba # main
         with:
           stable: true
 


### PR DESCRIPTION
- setup-homebrew: migrates to node24, silencing the Node 20 deprecation warning
- Default branch renamed from master to main; updates trailing comment to match (using `master` triggers a new deprecation warning as of the pinned-in SHA)

Compare: https://github.com/Homebrew/actions/compare/42435f26fd0824180d7a31f0dd75afd37eb2e18f...98cfa07b984a61682e6cd3a0833fad2006cc84ba

This pull request and its description were written by Isaac.