### PR TITLE
Document the Homebrew 6.0.0 tap trust requirement

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,12 @@ jobs:
   install:
     runs-on: ${{ matrix.os }}
 
+    # Homebrew 6.0.0 sandboxes installs on Linux using Bubblewrap (bwrap), which
+    # is not available as a working rootless executable on GitHub-hosted runners.
+    # Disable the Linux sandbox so installs work in CI (no effect on macOS).
+    env:
+      HOMEBREW_NO_SANDBOX_LINUX: 1
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,12 @@ jobs:
         with:
           stable: true
 
+      # Homebrew 6.0.0 refuses to load formulae from untrusted third-party taps.
+      # The tap installed above is not trusted by default, so trust it before use.
+      - name: Trust the tap
+        run: |
+          brew trust databricks/tap
+
       - name: Check the CLI formula
         run: |
           brew style databricks

--- a/README.md
+++ b/README.md
@@ -9,17 +9,26 @@ Full documentation about installation can be found at:
 
 ## Usage
 
-Initialize tap:
+Add the tap and trust it:
 
 ```bash
 brew tap databricks/tap
+brew trust databricks/tap
 ```
+
+`brew trust databricks/tap` is required as of [Homebrew 6.0.0](https://docs.brew.sh/Tap-Trust),
+which requires third-party taps to be trusted before Homebrew will load their
+formulae. Existing users who tapped before upgrading to Homebrew 6.0.0 need to
+run it once as well.
 
 To install or upgrade the Databricks CLI, run:
 
 ```bash
 brew install databricks
 ```
+
+(You can also install in a single step without trusting the whole tap with
+`brew install databricks/tap/databricks`.)
 
 If this tap has been updated but you don't see it show up locally, you can force an update with:
 
@@ -34,6 +43,7 @@ If you need to install an older version of the Databricks CLI, you can do so wit
 ```bash
 brew tap-new databricks/tap-old
 brew extract --version=0.218.0 databricks/tap/databricks databricks/tap-old
+brew trust databricks/tap-old
 brew install databricks@0.218.0
 
 # Unlink the latest version (if it's already installed)


### PR DESCRIPTION
Homebrew 6.0.0 requires third-party taps to be explicitly trusted before it will load their formulae. Update the install instructions to run `brew trust databricks/tap` after tapping, and add the matching `brew trust databricks/tap-old` step to the older-version instructions.

See https://docs.brew.sh/Tap-Trust.